### PR TITLE
Dont update images that aren't being started

### DIFF
--- a/update.go
+++ b/update.go
@@ -141,7 +141,9 @@ func checkUpdate(curProfile *Profile, all, force bool) error {
 	}
 	// add current profile's image
 	for _, i := range checkImageDate(curProfile, checkData, force) {
-		imagesMap[i] = true
+		if all || i.Platform == "linux/"+curProfile.Arch {
+			imagesMap[i] = true
+		}
 	}
 
 	if all {
@@ -173,10 +175,6 @@ func checkUpdate(curProfile *Profile, all, force bool) error {
 
 	var images []ImageDef
 	for i := range imagesMap {
-		if i.Image != curProfile.Image {
-			fmt.Printf("skipping update: %s|%s\n", i.Image, i.Platform)
-			continue
-		}
 		fmt.Printf("queuing update: %s|%s\n", i.Image, i.Platform)
 		images = append(images, i)
 	}
@@ -193,7 +191,7 @@ func checkImageDate(profile *Profile, checkData ImageCheckData, force bool) []Im
 		imageCandidates = append(imageCandidates, ImageDef{Image: profile.ImageAMD64, Platform: "linux/amd64"})
 		imageCandidates = append(imageCandidates, ImageDef{Image: profile.ImageARM64, Platform: "linux/arm64"})
 	case profile.Image != "":
-		imageCandidates = append(imageCandidates, ImageDef{Image: profile.Image, Platform: profile.Arch})
+		imageCandidates = append(imageCandidates, ImageDef{Image: profile.Image, Platform: "linux/" + profile.Arch})
 	default:
 		return images
 	}

--- a/update.go
+++ b/update.go
@@ -173,6 +173,10 @@ func checkUpdate(curProfile *Profile, all, force bool) error {
 
 	var images []ImageDef
 	for i := range imagesMap {
+		if i.Image != curProfile.Image {
+			fmt.Printf("skipping update: %s|%s\n", i.Image, i.Platform)
+			continue
+		}
 		fmt.Printf("queuing update: %s|%s\n", i.Image, i.Platform)
 		images = append(images, i)
 	}


### PR DESCRIPTION
The inspiration for this PR came while waiting for canon to download and unpack the 720MB `linux/arm64` image used for the rdk despite the fact that I was only starting `linux/amd64`.

I don't know this codebase in the slightest, so there might be a significantly more elegant way to accomplish this. Also, I have no easy way to know if this would break other parts of canon.


Tested with:
```
canon-default:
    image_amd64: "ghcr.io/viamrobotics/canon:amd64"
    image_arm64: "ghcr.io/viamrobotics/canon:arm64"
    update_interval: 0h0m1s
```

Sample output:
```
➜  canon git:(zp/skip) ✗ ./bin/canon
queuing update: ghcr.io/viamrobotics/canon:amd64|linux/amd64
skipping update: ghcr.io/viamrobotics/canon:arm64|linux/arm64
amd64: Pulling from viamrobotics/canon
Digest: sha256:88738041207b8909bb1d4e49e76da3e8c24f472f8a86af30dcbc467bbac289d9
Status: Image is up to date for ghcr.io/viamrobotics/canon:amd64
```
```
➜  canon git:(zp/skip) ✗ ./bin/canon --arch arm64
skipping update: ghcr.io/viamrobotics/canon:amd64|linux/amd64
queuing update: ghcr.io/viamrobotics/canon:arm64|linux/arm64
arm64: Pulling from viamrobotics/canon
Digest: sha256:4f58c0f5426cf83d2294bf057e19dbd5d140dcf67a29c1539a99be79f06870dd
Status: Image is up to date for ghcr.io/viamrobotics/canon:arm64
```