### PR TITLE
Detect and handle non-tty envs

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -133,6 +133,8 @@ func shell(args []string) (int, error) {
 			outErr <- err
 		}()
 	} else {
+		// Without TTY, Docker multiplexes stdout/stderr with headers.
+		// StdCopy demuxes them back to separate streams.
 		go func() {
 			_, err := stdcopy.StdCopy(os.Stdout, os.Stderr, hijack.Reader)
 			outErr <- err

--- a/shell.go
+++ b/shell.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/moby/term"
 )
 
@@ -75,13 +76,15 @@ func shell(args []string) (int, error) {
 		return ExitCodeOnError, err
 	}
 
+	isTTY := term.IsTerminal(os.Stdin.Fd())
+
 	execCfg := container.ExecOptions{
 		User:         fmt.Sprintf("%s:%s", activeProfile.User, activeProfile.Group),
 		WorkingDir:   wd,
 		AttachStdin:  true,
 		AttachStdout: true,
 		AttachStderr: true,
-		Tty:          true,
+		Tty:          isTTY,
 		Cmd:          args,
 	}
 	if sshSock != "" {
@@ -100,31 +103,41 @@ func shell(args []string) (int, error) {
 	}
 	defer hijack.Close()
 
-	// keep the TTY the same size in the container as on the host
-	err = resizeTty(ctx, cli, execID)
-	if err != nil {
-		// for very fast commands, the resize may happen too early or too late
-		if !strings.Contains(err.Error(), "cannot resize a stopped container") &&
-			!strings.Contains(err.Error(), "no such exec") {
+	if isTTY {
+		// keep the TTY the same size in the container as on the host
+		err = resizeTty(ctx, cli, execID)
+		if err != nil {
+			// for very fast commands, the resize may happen too early or too late
+			if !strings.Contains(err.Error(), "cannot resize a stopped container") &&
+				!strings.Contains(err.Error(), "no such exec") {
+				return ExitCodeOnError, err
+			}
+		}
+		monitorTtySize(ctx, cli, execID)
+
+		var termState *term.State
+		termState, err = term.SetRawTerminal(os.Stdin.Fd())
+		if err != nil {
 			return ExitCodeOnError, err
 		}
+		defer func() {
+			err = errors.Join(err, term.RestoreTerminal(os.Stdin.Fd(), termState))
+		}()
 	}
-	monitorTtySize(ctx, cli, execID)
-
-	termState, err := term.SetRawTerminal(os.Stdin.Fd())
-	if err != nil {
-		return ExitCodeOnError, err
-	}
-	defer func() {
-		err = errors.Join(err, term.RestoreTerminal(os.Stdin.Fd(), termState))
-	}()
 
 	outErr := make(chan (error))
 	inErr := make(chan (error))
-	go func() {
-		_, err := io.Copy(os.Stdout, hijack.Reader)
-		outErr <- err
-	}()
+	if isTTY {
+		go func() {
+			_, err := io.Copy(os.Stdout, hijack.Reader)
+			outErr <- err
+		}()
+	} else {
+		go func() {
+			_, err := stdcopy.StdCopy(os.Stdout, os.Stderr, hijack.Reader)
+			outErr <- err
+		}()
+	}
 	go func() {
 		_, err := io.Copy(hijack.Conn, os.Stdin)
 		inErr <- err

--- a/shell.go
+++ b/shell.go
@@ -121,7 +121,9 @@ func shell(args []string) (int, error) {
 			return ExitCodeOnError, err
 		}
 		defer func() {
-			err = errors.Join(err, term.RestoreTerminal(os.Stdin.Fd(), termState))
+			if restoreErr := term.RestoreTerminal(os.Stdin.Fd(), termState); restoreErr != nil {
+				err = errors.Join(err, restoreErr)
+			}
 		}()
 	}
 


### PR DESCRIPTION
## Description

Goal: Make it easier for claude and codex agents to use canon by adding a no-tty mode.

Naive canon cli use by coding agent:
```
  Error in main.main[/Users/sean/canon/main.go:66] inappropriate ioctl for device                                                                                                     
  EXIT CODE: 66
````
## Manual Tests
- tty mode still works from terminal
- non-tty agent use works
  - stdout and stderr coming through
    
Recommend setting `persistent: true` in the profile so claude/codex can easily chain together calls.
