### PR TITLE
Make chown step faster

### DIFF
--- a/canon_setup.sh
+++ b/canon_setup.sh
@@ -47,8 +47,8 @@ echo "# Fixing ownership on files in /home/$CANON_USER"
 echo "# This may take a while depending on the number of files."
 (set -x; mkdir -p "/home/$CANON_USER")
 # find files with wrong ownership, chown in parallel batches across all cores
-find "/home/$CANON_USER" \( ! -user $CANON_UID -o ! -group $CANON_GID \) -print0 | \
-  xargs -0 -r -P "$(nproc)" -n 100 chown -f $CANON_UID:$CANON_GID
+(set -x; find "/home/$CANON_USER" \( ! -user $CANON_UID -o ! -group $CANON_GID \) -print0 | \
+  xargs -0 -r -P "$(nproc)" -n 100 chown -f $CANON_UID:$CANON_GID)
 
 # group setup
 if getent group $CANON_GROUP >/dev/null; then

--- a/canon_setup.sh
+++ b/canon_setup.sh
@@ -46,7 +46,9 @@ fi
 echo "# Fixing ownership on files in /home/$CANON_USER"
 echo "# This may take a while depending on the number of files."
 (set -x; mkdir -p "/home/$CANON_USER")
-(set -x; chown -Rf $CANON_UID:$CANON_GID "/home/$CANON_USER")
+# find files with wrong ownership, chown in parallel batches across all cores
+find "/home/$CANON_USER" \( ! -user $CANON_UID -o ! -group $CANON_GID \) -print0 | \
+  xargs -0 -r -P "$(nproc)" -n 100 chown $CANON_UID:$CANON_GID
 
 # group setup
 if getent group $CANON_GROUP >/dev/null; then

--- a/canon_setup.sh
+++ b/canon_setup.sh
@@ -48,7 +48,7 @@ echo "# This may take a while depending on the number of files."
 (set -x; mkdir -p "/home/$CANON_USER")
 # find files with wrong ownership, chown in parallel batches across all cores
 find "/home/$CANON_USER" \( ! -user $CANON_UID -o ! -group $CANON_GID \) -print0 | \
-  xargs -0 -r -P "$(nproc)" -n 100 chown $CANON_UID:$CANON_GID
+  xargs -0 -r -P "$(nproc)" -n 100 chown -f $CANON_UID:$CANON_GID
 
 # group setup
 if getent group $CANON_GROUP >/dev/null; then


### PR DESCRIPTION
## Description
- Parallelize chown across cores in 100 file batches
- No-op handling to avoid chown'ing files that already have correct permissions

## Testing
Tested on fake dir with 50k flat files:

```
  ┌─────────────────────────┬────────┐                                                                                                  
  │        Scenario         │  Time  │                                                                                                  
  ├─────────────────────────┼────────┤                                                                                                  
  │ Old chown -Rf           │ 0.396s │                                                                                                  
  ├─────────────────────────┼────────┤
  │ New parallel find|xargs │ 0.140s │                                                                                                  
  ├─────────────────────────┼────────┤
  ```