### PR TITLE
Fix $HOME env leaking as /root for non-root users

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -78,17 +78,24 @@ func shell(args []string) (int, error) {
 
 	isTTY := term.IsTerminal(os.Stdin.Fd())
 
+	home := "/root"
+	if activeProfile.User != "root" {
+		home = "/home/" + activeProfile.User
+	}
+	env := []string{"HOME=" + home}
+	if sshSock != "" {
+		env = append(env, "SSH_AUTH_SOCK="+sshSock)
+	}
+
 	execCfg := container.ExecOptions{
 		User:         fmt.Sprintf("%s:%s", activeProfile.User, activeProfile.Group),
 		WorkingDir:   wd,
+		Env:          env,
 		AttachStdin:  true,
 		AttachStdout: true,
 		AttachStderr: true,
 		Tty:          isTTY,
 		Cmd:          args,
-	}
-	if sshSock != "" {
-		execCfg.Env = []string{"SSH_AUTH_SOCK=" + sshSock}
 	}
 
 	execResp, err := cli.ContainerExecCreate(ctx, containerID, execCfg)


### PR DESCRIPTION
## Description

Our shell entrypoint was not setting HOME correctly.

The common pattern is to set `testbot` user and group in the `canon.yml` config:
```yaml
csi-jetson:
  default: true
  image_arm64: ghcr.io/viam-modules/csi-camera/viam-cpp-base-jetson:0.0.8
  minimum_date: 2023-10-26T20:00:00.0Z
  update_interval: 168h0m0s
  user: testbot
  group: testbot
  persistent: true
```

Noticed `buf` use was failing in the container because it was picking up HOME as `/root`.


## Testing

claude smoke test:

```
  TEST 1 — HOME reflects the actual user:                                                                                              
  canon bash -c 'echo "HOME=$HOME"; id'
  → HOME=/home/testbot (was /root before the fix), uid=501(testbot). Pre-fix this would have printed HOME=/root.                       
                                                                                                                
  TEST 2 — $HOME is writable as testbot:                                                                                               
  canon bash -c 'touch $HOME/.canon-smoke && ls -la $HOME/.canon-smoke && rm $HOME/.canon-smoke'                                       
  → Created and removed the file successfully. Pre-fix: permission denied (testbot can't write to /root).                              
                                                                                                                                       
  TEST 3 — cd $HOME lands in a real, readable dir:                                                                                     
  canon bash -c 'cd $HOME && pwd && ls -la .config/ | head -5'                                                                         
  → pwd printed /home/testbot, .config/ listed (showing buf/ subdir). Pre-fix: cd $HOME would land in /root and ls .config/ would fail 
  with permission denied — exactly the original buf failure mode.       
```


